### PR TITLE
Fix Aborted (core dumped) in Ubuntu 20.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+unjzp
+packjzp
+
+**/*.o

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ unjzp
 packjzp
 
 **/*.o
+**/*.jzp

--- a/unjzp.cpp
+++ b/unjzp.cpp
@@ -67,7 +67,7 @@ int decompress( const void *inbuf, const unsigned inlen, void *outbuf)
   		if (in->empty())
      			puts("  IN is empty");
   		else
-     			printf("  IN used %X of %X\n", in->used(), swapl(hdr->comp_size) - sizeof(JZPHDR));
+     			printf("  IN used %X of %lu\n", in->used(), swapl(hdr->comp_size) - sizeof(JZPHDR));
   		if (out->full())
      			puts("  OUT is full");
   		else

--- a/util/BinFile.cpp
+++ b/util/BinFile.cpp
@@ -20,4 +20,6 @@ bool SaveBinFile(const char *fname, const void *data, unsigned size)
 {
 	std::ofstream file(fname, std::ios::binary | std::ios::trunc);
 	file.write((const char*)data, size);
+	file.flush();
+	return file.bad();
 }


### PR DESCRIPTION
SaveBinFile() should return a bool value but void. That causes core dumped.